### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,12 @@
   },
   "dependencies": {
     "colors": "~0.6.2"
-  }
+  },
+  "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mcwhittemore/hooks-config.git"
+  },
+  "bugs": "https://github.com/mcwhittemore/hooks-config/issues",
+  "homepage": "https://github.com/mcwhittemore/hooks-config"
 }


### PR DESCRIPTION
Adding repo/bugs/homepage URLs to make it a bit more npm friendly.
Everything should now be http://package-json-validator.com/ compatible.
